### PR TITLE
pip install SchemaObject breaks; ez_setup not included in distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include README CHANGES *.py
+recursive-include schemaobject *.py


### PR DESCRIPTION
Probably just need to include ez_setup in MANIFEST.in, but here's the output:

    [prompt]$ pip install SchemaObject
    Downloading/unpacking SchemaObject
      Running setup.py egg_info for package SchemaObject
        Traceback (most recent call last):
          File "<string>", line 14, in <module>
          File "/path/to/virtualenv/build/SchemaObject/setup.py", line 2, in <module>
            import ez_setup
        ImportError: No module named ez_setup
        Complete output from command python setup.py egg_info:
        Traceback (most recent call last):

      File "<string>", line 14, in <module>

      File "/path/to/virtualenv/build/SchemaObject/setup.py", line 2, in <module>

        import ez_setup
 
    ImportError: No module named ez_setup

    ----------------------------------------
    Command python setup.py egg_info failed with error code 1 in /path/to/virtualenv/build/SchemaObject
