### PR TITLE
Fix for working with MySQL-python==1.2.5

### DIFF
--- a/schemaobject/connection.py
+++ b/schemaobject/connection.py
@@ -60,6 +60,8 @@ class DatabaseConnection(object):
 
     def execute(self, sql, values=None):
         cursor = self._db.cursor()
+        if isinstance(values, (basestring, unicode)):
+            values = (values,)
         cursor.execute(sql, values)
 
         if not cursor.rowcount:


### PR DESCRIPTION
Cursor in current version of MySQL driver assumes that `values` given to `execute` method is a sequence or mapping. If `values` will be a string, it will convert it to tuple of chars and raise TypeError while trying to use it for query:

```python
"SELECT ... WHERE SCHEMA_NAME = %s" % ('s', 'a', 'k', 'i', 'l', 'a')
```