### PR TITLE
fix unicode default string  error

### DIFF
--- a/schemaobject/column.py
+++ b/schemaobject/column.py
@@ -140,7 +140,12 @@ class ColumnSchema(object):
         else:
             sql.append("NULL")
 
-        if self.default is not None and isinstance(self.default, (str, unicode)) \
+        try:
+            basestring
+        except NameError:
+            basestring = str
+
+        if self.default is not None and isinstance(self.default, (str, basestring)) \
                 and self.default != 'CURRENT_TIMESTAMP':
             sql.append("DEFAULT '%s'" % self.default)
         elif self.default is not None:

--- a/schemaobject/column.py
+++ b/schemaobject/column.py
@@ -140,7 +140,8 @@ class ColumnSchema(object):
         else:
             sql.append("NULL")
 
-        if self.default is not None and isinstance(self.default, str) and self.default is not 'CURRENT_TIMESTAMP':
+        if self.default is not None and isinstance(self.default, (str, unicode)) \
+                and self.default != 'CURRENT_TIMESTAMP':
             sql.append("DEFAULT '%s'" % self.default)
         elif self.default is not None:
             sql.append("DEFAULT %s" % self.default)


### PR DESCRIPTION
Compatible with unicode type. Fix sql syntax error
ADD COLUMN `remark` varchar(50) NULL DEFAULT '*' FIRST
ADD COLUMN `remark` varchar(50) NULL DEFAULT * FIRST