### PR TITLE
Fix for python3

### DIFF
--- a/schemaobject/__init__.py
+++ b/schemaobject/__init__.py
@@ -4,7 +4,7 @@ __copyright__ = """
 Copyright 2009-2016 Mitch Matuson
 Copyright 2016 Mustafa Ozgur
 """
-__version__ = "0.5.8"
+__version__ = "0.5.9"
 __license__ = "Apache 2.0"
 
 # shortcut to SchemaObject()

--- a/schemaobject/connection.py
+++ b/schemaobject/connection.py
@@ -69,7 +69,13 @@ class DatabaseConnection(object):
 
     def execute(self, sql, values=None):
         cursor = self._db.cursor()
-        if isinstance(values, (basestring, unicode)):
+
+        try:
+            basestring
+        except NameError:
+            basestring = str
+
+        if isinstance(values, (str, basestring)):
             values = (values,)
         cursor.execute(sql, values)
 


### PR DESCRIPTION
Fix references to basestring

Once merged, please be sure to update mmatuson/SchemaSync to require the new version, as it currently breaks on Python3 due to this issue.